### PR TITLE
Disallow Invalid field orders, additional fields, and unknown hashes

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,25 @@ var ssbKeys = require('ssb-keys')
 var isHash = ref.isHash
 var isFeedId = ref.isFeedId
 
+function isValidOrder (msg, signed) {
+  var i = 0
+  var keys = Object.keys(msg)
+  if(
+    keys[0] !== 'previous' ||
+    keys[3] !== 'timestamp' ||
+    keys[4] !== 'hash' ||
+    keys[5] !== 'content' ||
+    (signed && keys[6] !== 'signature')
+  ) return false
+  //author and signature may be swapped.
+  if(!(
+    (keys[1] === 'sequence' && keys[2] === 'author') ||
+    (keys[1] === 'author' && keys[2] === 'sequence')
+  ))
+    return false
+  return true
+}
+
 var encode = exports.encode = function (obj) {
   return JSON.stringify(obj, null, 2)
 }
@@ -49,12 +68,18 @@ var isInvalidContent = exports.isInvalidContent = function (content) {
   return false
 }
 
+var isSupportedHash = exports.isSupportedHash = function (msg) {
+  return msg.hash === 'sha256'
+}
+
 var isInvalidShape = exports.isInvalidShape = function (msg) {
   if(
     !isObject(msg) ||
     !isInteger(msg.sequence) ||
     !isFeedId(msg.author) ||
-    !(isObject(msg.content) || isEncrypted(msg.content))
+    !(isObject(msg.content) || isEncrypted(msg.content)) ||
+    !isValidOrder(msg, false) || //false, because message may not be signed yet.
+    !isSupportedHash(msg)
   )
     return new Error('message has invalid properties:'+JSON.stringify(msg, null, 2))
 
@@ -104,6 +129,11 @@ exports.checkInvalidCheap = function (state, msg) {
     if('number' !== typeof msg.timestamp)
       return fatal(new Error('initial message must have timestamp, on feed:'+msg.author))
   }
+  if(!isValidOrder(msg, true))
+    return fatal(new Error('message must have keys in allowed order'))
+  if(!isSupportedHash(msg))
+    return fatal(new Error('message had an unknown hash'))
+
   return isInvalidShape(msg)
 }
 

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ var isFeedId = ref.isFeedId
 function isValidOrder (msg, signed) {
   var i = 0
   var keys = Object.keys(msg)
+  if(signed && keys.length !== 7) return false
   if(
     keys[0] !== 'previous' ||
     keys[3] !== 'timestamp' ||
@@ -252,4 +253,5 @@ exports.appendNew = function (state, hmac_key, keys, content, timestamp) {
   state = exports.append(state, hmac_key, msg)
   return state
 }
+
 

--- a/test/data/test_messages.json
+++ b/test/data/test_messages.json
@@ -207,6 +207,81 @@
     "valid": false
   },
   {
+    "state": {
+      "queue": [],
+      "feeds": {},
+      "validated": 0
+    },
+    "msg": {
+      "previous": null,
+      "author": "@AzvddyStfk/T95/3VuHxuJRwqqpBkCyoW7qHRCui2N4=.ed25519",
+      "sequence": 1,
+      "timestamp": 1491901740000,
+      "hash": "oanteuhnoatehuneotuh",
+      "content": {
+        "type": "invalid"
+      },
+      "signature": "7H5gOI7x+Vav2g3ef+rVur4ds24zje5iYG1VxkS2GlbSR99/iqCvp6Xzk3za9NzaUakW0PHTlx8Mt8rRZa58Cg==.sig.ed25519"
+    },
+    "valid": false
+  },
+  {
+    "state": {
+      "queue": [],
+      "feeds": {},
+      "validated": 0
+    },
+    "msg": {
+      "previous": null,
+      "author": "@AzvddyStfk/T95/3VuHxuJRwqqpBkCyoW7qHRCui2N4=.ed25519",
+      "sequence": 1,
+      "timestamp": 1491901740000,
+      "content": {
+        "type": "invalid"
+      },
+      "signature": "isRUtaemxKUjIDgj0v6gASafokhjMM4z7LJ9rz5JFZNWpolAy6eYO4RUzcUYhitQ7qG27PbzivswTjeChG5VBQ==.sig.ed25519"
+    },
+    "valid": false
+  },
+  {
+    "state": {
+      "queue": [],
+      "feeds": {},
+      "validated": 0
+    },
+    "msg": {
+      "content": {
+        "type": "invalid"
+      },
+      "hash": "sha256",
+      "author": "@AzvddyStfk/T95/3VuHxuJRwqqpBkCyoW7qHRCui2N4=.ed25519",
+      "timestamp": 1491901740000,
+      "sequence": 1,
+      "previous": null,
+      "signature": "diO4R0yxFCsdQH5rdiW3XYhbaPF0QtwsCYGEhE7iQZqx746famQ1QBbmP7O0ZhBAnabsk77PcHSX5OFfjCJ7BQ==.sig.ed25519"
+    },
+    "valid": false
+  },
+  {
+    "state": {
+      "queue": [],
+      "feeds": {},
+      "validated": 0
+    },
+    "msg": {
+      "previous": null,
+      "author": "@AzvddyStfk/T95/3VuHxuJRwqqpBkCyoW7qHRCui2N4=.ed25519",
+      "sequence": 1,
+      "timestamp": 1491901740000,
+      "content": {
+        "type": "invalid"
+      },
+      "hash": "sha256",
+      "signature": "5yqUqG+OoTZgQSBNBeoqVbtFqWnu9r4MadmwUJ4J3zY2YqJ3BxFJ+LR8t+8ntIRVbO0M8PWpsfARC/3eWuesDA==.sig.ed25519"
+    },
+    "valid": false
+  },
+  {
     "state": null,
     "msg": {
       "previous": null,
@@ -218,6 +293,36 @@
         "type": "TTT"
       },
       "signature": "8XdA3TwXsWasY8PGo5zI/QJAi6XsyCklzQv8dVtgOEZk4jRCVFDLb4OCK7H/s+lxOcxjpKn4NGocbQ7Z5mF5CQ==.sig.ed25519"
+    },
+    "valid": true
+  },
+  {
+    "state": null,
+    "msg": {
+      "previous": null,
+      "author": "@AzvddyStfk/T95/3VuHxuJRwqqpBkCyoW7qHRCui2N4=.ed25519",
+      "sequence": 1,
+      "timestamp": 1491901740000,
+      "hash": "sha256",
+      "content": {
+        "type": "valid"
+      },
+      "signature": "er89Fh7ElIU2V+C0NMYf6pKAdGXAWKcBYDXJozlzpEVyse474eC31M8k+XPRsnuz86A0L+FBTT3HqfM4DD4YCg==.sig.ed25519"
+    },
+    "valid": true
+  },
+  {
+    "state": null,
+    "msg": {
+      "previous": null,
+      "sequence": 1,
+      "author": "@AzvddyStfk/T95/3VuHxuJRwqqpBkCyoW7qHRCui2N4=.ed25519",
+      "timestamp": 1491901740000,
+      "hash": "sha256",
+      "content": {
+        "type": "valid"
+      },
+      "signature": "Org411/AHNgUHy77yj1+4oByr0EHPhvO72KJDwOmJ21hdMdlPG31Oi3EY2BpVBNJf9mqmUugrppyw3Q+Zc6DBA==.sig.ed25519"
     },
     "valid": true
   },
@@ -516,6 +621,85 @@
     "valid": false
   },
   {
+    "state": {
+      "queue": [],
+      "feeds": {},
+      "validated": 0
+    },
+    "msg": {
+      "previous": null,
+      "author": "@AzvddyStfk/T95/3VuHxuJRwqqpBkCyoW7qHRCui2N4=.ed25519",
+      "sequence": 1,
+      "timestamp": 1491901740000,
+      "hash": "oanteuhnoatehuneotuh",
+      "content": {
+        "type": "invalid"
+      },
+      "signature": "9OAbsQs2qhSLhjKH6DRoJepk/pMLnyFux87Xm+Oz4otTwocYdKeXZuHMj+6tzZJ7jzYpqNmh8sQ/vTtRCUFZCg==.sig.ed25519"
+    },
+    "cap": "Z0e2zyrmHeit5ydNjaw2bLlrHBwx9UcivTAAGquwQ+Y=",
+    "valid": false
+  },
+  {
+    "state": {
+      "queue": [],
+      "feeds": {},
+      "validated": 0
+    },
+    "msg": {
+      "previous": null,
+      "author": "@AzvddyStfk/T95/3VuHxuJRwqqpBkCyoW7qHRCui2N4=.ed25519",
+      "sequence": 1,
+      "timestamp": 1491901740000,
+      "content": {
+        "type": "invalid"
+      },
+      "signature": "sI9Nhe0HRC/W0q1DrgB4t0gkuBXLdgU6JMwZS59d6ZAitbF12H+6u9vXnE7ssikw4B4v+D0IvCSB2jRhXDICBw==.sig.ed25519"
+    },
+    "cap": "Z0e2zyrmHeit5ydNjaw2bLlrHBwx9UcivTAAGquwQ+Y=",
+    "valid": false
+  },
+  {
+    "state": {
+      "queue": [],
+      "feeds": {},
+      "validated": 0
+    },
+    "msg": {
+      "content": {
+        "type": "invalid"
+      },
+      "hash": "sha256",
+      "author": "@AzvddyStfk/T95/3VuHxuJRwqqpBkCyoW7qHRCui2N4=.ed25519",
+      "timestamp": 1491901740000,
+      "sequence": 1,
+      "previous": null,
+      "signature": "HWzuIG7Lkw6pbwf1Cdcgw4EIvjcljLar4TFpF7CKlVjPDb8oq909NLr5Z85P/qGRw8vIQUbGDSY7ci+6W218AA==.sig.ed25519"
+    },
+    "cap": "Z0e2zyrmHeit5ydNjaw2bLlrHBwx9UcivTAAGquwQ+Y=",
+    "valid": false
+  },
+  {
+    "state": {
+      "queue": [],
+      "feeds": {},
+      "validated": 0
+    },
+    "msg": {
+      "previous": null,
+      "author": "@AzvddyStfk/T95/3VuHxuJRwqqpBkCyoW7qHRCui2N4=.ed25519",
+      "sequence": 1,
+      "timestamp": 1491901740000,
+      "content": {
+        "type": "invalid"
+      },
+      "hash": "sha256",
+      "signature": "cr9jnhmtBht0MkpA7rndmY7b++6Cfr5mFTNJuu0UYerrNP2fswPtiD6b2frEkfHLBnZHOY1+jmyWOgiDQgKaCw==.sig.ed25519"
+    },
+    "cap": "Z0e2zyrmHeit5ydNjaw2bLlrHBwx9UcivTAAGquwQ+Y=",
+    "valid": false
+  },
+  {
     "state": null,
     "msg": {
       "previous": null,
@@ -527,6 +711,38 @@
         "type": "TTT"
       },
       "signature": "HR3lI0pOTYaaKTWwI5yBr88anTIOsp4MkxohnPDXuohKfgWUQh8loOJxbnpoQ1WveRtmY9O18xSXUR/3zK3sAg==.sig.ed25519"
+    },
+    "cap": "Z0e2zyrmHeit5ydNjaw2bLlrHBwx9UcivTAAGquwQ+Y=",
+    "valid": true
+  },
+  {
+    "state": null,
+    "msg": {
+      "previous": null,
+      "author": "@AzvddyStfk/T95/3VuHxuJRwqqpBkCyoW7qHRCui2N4=.ed25519",
+      "sequence": 1,
+      "timestamp": 1491901740000,
+      "hash": "sha256",
+      "content": {
+        "type": "valid"
+      },
+      "signature": "/pyzCXbQt9kmtX+48eEaQ0jCYCZUOaYinM+Rhwnc09C3DdoZkhvmpBHbp5wRjoiWSNgWZBL7Eq46MFVENXXAAg==.sig.ed25519"
+    },
+    "cap": "Z0e2zyrmHeit5ydNjaw2bLlrHBwx9UcivTAAGquwQ+Y=",
+    "valid": true
+  },
+  {
+    "state": null,
+    "msg": {
+      "previous": null,
+      "sequence": 1,
+      "author": "@AzvddyStfk/T95/3VuHxuJRwqqpBkCyoW7qHRCui2N4=.ed25519",
+      "timestamp": 1491901740000,
+      "hash": "sha256",
+      "content": {
+        "type": "valid"
+      },
+      "signature": "L5+CycD5dUDMrEUr2kL+t2S+fHFQtvo3D9n7f9DaG9cjNg5Tzul6y/+INToQt3qsiCaaZVi7Zq3G6n60vIyeCA==.sig.ed25519"
     },
     "cap": "Z0e2zyrmHeit5ydNjaw2bLlrHBwx9UcivTAAGquwQ+Y=",
     "valid": true
@@ -831,6 +1047,85 @@
     "valid": false
   },
   {
+    "state": {
+      "queue": [],
+      "feeds": {},
+      "validated": 0
+    },
+    "msg": {
+      "previous": null,
+      "author": "@AzvddyStfk/T95/3VuHxuJRwqqpBkCyoW7qHRCui2N4=.ed25519",
+      "sequence": 1,
+      "timestamp": 1491901740000,
+      "hash": "oanteuhnoatehuneotuh",
+      "content": {
+        "type": "invalid"
+      },
+      "signature": "HKUXsMwJxSShpOdTGgyv1Oi51JbMu0S5f6lCsTQWOj6ldzeydYkzDx3ivcDDD4ehNJMqycm45qaKvsHLQ4KLAw==.sig.ed25519"
+    },
+    "cap": "hzUz4WE4y+96ZiKqhACK3Z3/zuLD6PYTHOZUbbDmass=",
+    "valid": false
+  },
+  {
+    "state": {
+      "queue": [],
+      "feeds": {},
+      "validated": 0
+    },
+    "msg": {
+      "previous": null,
+      "author": "@AzvddyStfk/T95/3VuHxuJRwqqpBkCyoW7qHRCui2N4=.ed25519",
+      "sequence": 1,
+      "timestamp": 1491901740000,
+      "content": {
+        "type": "invalid"
+      },
+      "signature": "PUOKJCd74rT/ogzwEJ0HFKP6ARcrnJPJQfRBFu6U14qwIYTg4AnEhdjIa8VD1vITGnjrIgDBixBeDj35l2SkCA==.sig.ed25519"
+    },
+    "cap": "hzUz4WE4y+96ZiKqhACK3Z3/zuLD6PYTHOZUbbDmass=",
+    "valid": false
+  },
+  {
+    "state": {
+      "queue": [],
+      "feeds": {},
+      "validated": 0
+    },
+    "msg": {
+      "content": {
+        "type": "invalid"
+      },
+      "hash": "sha256",
+      "author": "@AzvddyStfk/T95/3VuHxuJRwqqpBkCyoW7qHRCui2N4=.ed25519",
+      "timestamp": 1491901740000,
+      "sequence": 1,
+      "previous": null,
+      "signature": "UNZ7tRQDRMe7rYBq8SVQYWlwNejPHy9aF1HQPF8yfhSfc+GuqSRXxw46x0z6962qJj+IwwSKwn/gZNDpuc1ADw==.sig.ed25519"
+    },
+    "cap": "hzUz4WE4y+96ZiKqhACK3Z3/zuLD6PYTHOZUbbDmass=",
+    "valid": false
+  },
+  {
+    "state": {
+      "queue": [],
+      "feeds": {},
+      "validated": 0
+    },
+    "msg": {
+      "previous": null,
+      "author": "@AzvddyStfk/T95/3VuHxuJRwqqpBkCyoW7qHRCui2N4=.ed25519",
+      "sequence": 1,
+      "timestamp": 1491901740000,
+      "content": {
+        "type": "invalid"
+      },
+      "hash": "sha256",
+      "signature": "7Z5YDuudQHNV5TcUjd/6Rlf1etSiOch+iiS9i+jwoTqGcB1vU5mCw0hOh7ZjEszrxkZVMc8bOU2e2MoNYQLEDQ==.sig.ed25519"
+    },
+    "cap": "hzUz4WE4y+96ZiKqhACK3Z3/zuLD6PYTHOZUbbDmass=",
+    "valid": false
+  },
+  {
     "state": null,
     "msg": {
       "previous": null,
@@ -842,6 +1137,38 @@
         "type": "TTT"
       },
       "signature": "/RqLFFwukKYpY7TtQPG/4C1HJZ78jBNg35etnJZ9EpyOf3pB+ZeJ1tbaEaM8ln81PRT8eRLgcAPjp+mYyHn8Cg==.sig.ed25519"
+    },
+    "cap": "hzUz4WE4y+96ZiKqhACK3Z3/zuLD6PYTHOZUbbDmass=",
+    "valid": true
+  },
+  {
+    "state": null,
+    "msg": {
+      "previous": null,
+      "author": "@AzvddyStfk/T95/3VuHxuJRwqqpBkCyoW7qHRCui2N4=.ed25519",
+      "sequence": 1,
+      "timestamp": 1491901740000,
+      "hash": "sha256",
+      "content": {
+        "type": "valid"
+      },
+      "signature": "1y5VoU1QZRKKE2lUD4yM+9O/Q9jo4V1PpUU89g6lF84TILfte1thAL3DV47wO+hmK3k5Y8SOW+BM31ogkq58Dg==.sig.ed25519"
+    },
+    "cap": "hzUz4WE4y+96ZiKqhACK3Z3/zuLD6PYTHOZUbbDmass=",
+    "valid": true
+  },
+  {
+    "state": null,
+    "msg": {
+      "previous": null,
+      "sequence": 1,
+      "author": "@AzvddyStfk/T95/3VuHxuJRwqqpBkCyoW7qHRCui2N4=.ed25519",
+      "timestamp": 1491901740000,
+      "hash": "sha256",
+      "content": {
+        "type": "valid"
+      },
+      "signature": "uBdpxnMbJZ702s+oux8OrGwxyoQcTRZE4AOSlTMA6sHwhEsYwnBWkmizLcBfYcQJBv0f3HpM2p6YwF44hT6qCw==.sig.ed25519"
     },
     "cap": "hzUz4WE4y+96ZiKqhACK3Z3/zuLD6PYTHOZUbbDmass=",
     "valid": true

--- a/test/error.js
+++ b/test/error.js
@@ -46,6 +46,7 @@ function test (hmac_key) {
 
     for(var i = 0; i < state.queue.length; i++) {
       try {
+        console.log(state.queue[i])
         state = v.append(state, hmac_key, state.queue[i])
         t.fail('should have thrown')
       } catch (err) {
@@ -142,6 +143,28 @@ function test (hmac_key) {
     })
   }
 
+  //create invalid messages with invalid orders
+  function test_invalid_msg(t, state, keys, hmac_key, _msg) {
+    var msg = ssbKeys.signObj(keys, hmac_key, _msg)
+    if(!state)
+      state = {
+        queue: [],
+        feeds: {},
+        validated: 0
+      }
+    data.push({state: state, msg: msg, cap: hmac_key, valid: false})
+
+    t.throws(function () {
+      console.log(v.append(state, hmac_key, msg))
+    })
+    t.throws(function () {
+      var _state = {feeds: {}}
+      _state.feeds[keys.id] = state
+      v.append(_state, hmac_key, msg)
+    })
+  }
+
+
   function test_valid(t, state, keys, hmac_key, content, timestamp) {
     var msg
     msg = v.create(state, keys, hmac_key, content, timestamp)
@@ -153,6 +176,15 @@ function test (hmac_key) {
     t.equal(msg.timestamp, timestamp)
 
   }
+
+  function test_valid_msg(t, state, keys, hmac_key, _msg) {
+    var msg = ssbKeys.signObj(keys, hmac_key, _msg)
+    data.push({state: state, msg: msg, cap: hmac_key, valid: true})
+    var _state = {queue: [], feeds: {}}
+    _state.feeds[keys.id] = state
+    v.append(_state, hmac_key, msg)
+  }
+
 
   var invalid = []
 
@@ -191,11 +223,73 @@ function test (hmac_key) {
     t.end()
   })
 
+  tape('extended invalid first messages', function (t) {
+    var date = +new Date('2017-04-11 9:09 UTC')
+    test_invalid_msg(t, null, keys, hmac_key, {
+      previous: null,
+      author: keys.id,
+      sequence: 1,
+      timestamp: +date,
+      hash: 'oanteuhnoatehuneotuh', //unsupported hash
+      content: {type:'invalid'}
+    })
+    test_invalid_msg(t, null, keys, hmac_key, {
+      previous: null,
+      author: keys.id,
+      sequence: 1,
+      timestamp: +date,
+      //missing hash
+      content: {type:'invalid'}
+    })
+    //invalid orders
+    test_invalid_msg(t, null, keys, hmac_key, {
+      content: {type:'invalid'},
+      hash: 'sha256',
+      author: keys.id,
+      timestamp: +date,
+      sequence: 1,
+      previous: null,
+    })
+    test_invalid_msg(t, null, keys, hmac_key, {
+      previous: null,
+      author: keys.id,
+      sequence: 1,
+      timestamp: +date,
+      content: {type:'invalid'},
+      hash: 'sha256',
+    })
+
+    t.end()
+  })
+
   tape('valid messages', function (t) {
     var msg
 
     //type must be 3 chars
     test_valid(t, null, keys, hmac_key, {type:'TTT' }, +new Date('2017-04-11 9:09 UTC'))
+
+    //author and sequence fields may come in either order!
+    //all other fields must be in exact order.
+    test_valid_msg(t, null, keys, hmac_key, {
+      previous: null,
+
+      author: keys.id, sequence: 1,
+
+      timestamp: +new Date('2017-04-11 9:09 UTC'),
+      hash: 'sha256',
+      content: { type: 'valid' }
+    })
+
+    test_valid_msg(t, null, keys, hmac_key, {
+      previous: null,
+
+      sequence: 1, author: keys.id,
+
+      timestamp: +new Date('2017-04-11 9:09 UTC'),
+      hash: 'sha256',
+      content: { type: 'valid' }
+    })
+
 
     //type can be msg id
     var msg_id = '%'+hash('test_msg_id').toString('base64')+'.sha256'
@@ -243,4 +337,10 @@ tape('write data', function (t) {
   fs.writeFileSync(path.join(__dirname, 'data', 'test_messages.json'), JSON.stringify(data, null, 2))
   t.end()
 })
+
+
+
+
+
+
 

--- a/test/error.js
+++ b/test/error.js
@@ -262,6 +262,40 @@ function test (hmac_key) {
     t.end()
   })
 
+  tape('disallow extra fields', function (t) {
+
+    var msg = ssbKeys.signObj(keys, hmac_key, {
+      previous: null,
+      author: keys.id,
+      sequence: 1,
+      timestamp: +new Date('2017-04-11 9:09 UTC'),
+      hash: 'sha256',
+      content: {type: 'invalid'},
+      extra: 'INVALID'
+    })
+    var signature = msg.signature
+    delete msg.signature
+    delete msg.extra
+    msg.signature = signature
+    msg.extra = 'INVALID'
+    var state = {
+      queue: [],
+      feeds: {},
+      validated: 0
+    }
+    data.push({state: state, msg: msg, cap: hmac_key, valid: false})
+
+    t.throws(function () {
+      console.log(v.append(state, hmac_key, msg))
+    })
+    t.throws(function () {
+      var _state = {feeds: {}}
+      _state.feeds[keys.id] = state
+      v.append(_state, hmac_key, msg)
+    })
+    t.end()
+  })
+
   tape('valid messages', function (t) {
     var msg
 


### PR DESCRIPTION
This clarifies some remaining wobbly bits in the implicit signing format.

fields on the top level object MUST be in either of the following orders.
```
previous,author,sequence,timestamp,hash,content,signature'
previous,sequence,author,timestamp,hash,content,signature'
```
it is recommended to produce the former (author, sequence) but implementors MUST accept the latter (sequence, author)

All other fields must have a fixed order.
hash must be included, and should point to a known hash & encoding. additional encodings and hashes may be added later, but implementations should not accept messages with hashes they do not understand.

finally, the number of fields is required to be exactly 7.