### PR TITLE
assert canonical base64 on top level properties

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "url": "git://github.com/dominictarr/ssb-validate.git"
   },
   "dependencies": {
+    "canonical-base64": "^1.1.0",
     "ssb-ref": "^2.6.2"
   },
   "devDependencies": {


### PR DESCRIPTION
`previous, author, signature` and `content` (if it's a string) are now checked to be valid canonical base64 strings. strings inside content are not checked (they may be inside markdown text anyway) are not checked.
It makes sense that another implementation may wish to encode the top level object in a binary representation, but I think if they encounter strings within the content that are not canonical base64 they should consider them invalid, and just represent them as arbitrary strings.

@AljoschaMeyer 