### PR TITLE
Use KVT in queue

### DIFF
--- a/index.js
+++ b/index.js
@@ -190,10 +190,11 @@ function flatState (fstate) {
     return fstate
 }
 
-exports.append = function (state, hmac_key, msg) {
+exports.append_kvt = function (state, hmac_key, kvt) {
   var err
+  var msg_id = kvt.key
+  var msg = kvt.value
   var _state = flatState(state.feeds[msg.author])
-  var msg_id = exports.id(msg)
 
   if(err = exports.checkInvalid(_state, hmac_key, msg))
     throw err
@@ -222,9 +223,13 @@ exports.append = function (state, hmac_key, msg) {
     state.waiting.push(msg)
   }
 
-  state.queue.push(exports.toKeyValueTimestamp(msg, msg_id))
+  state.queue.push(kvt)
   state.validated += 1
   return state
+}
+
+exports.append = function (state, hmac_key, msg) {
+  return exports.append_kvt(state, hmac_key, exports.toKeyValueTimestamp(msg))
 }
 
 exports.validate = function (state, hmac_key, feed) {
@@ -233,7 +238,7 @@ exports.validate = function (state, hmac_key, feed) {
   }
   var kvt = state.feeds[feed].queue.pop()
   state.queued -= 1
-  return exports.append(state, hmac_key, kvt.value)
+  return exports.append_kvt(state, hmac_key, kvt)
 }
 
 //pass in your own timestamp, so it's completely deterministic

--- a/index.js
+++ b/index.js
@@ -132,8 +132,6 @@ exports.checkInvalidCheap = function (state, msg) {
   }
   if(!isValidOrder(msg, true))
     return fatal(new Error('message must have keys in allowed order'))
-  if(!isSupportedHash(msg))
-    return fatal(new Error('message had an unknown hash'))
 
   return isInvalidShape(msg)
 }

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "url": "git://github.com/dominictarr/ssb-validate.git"
   },
   "dependencies": {
+    "monotonic-timestamp": "0.0.9",
     "ssb-ref": "^2.6.2"
   },
   "devDependencies": {

--- a/test/generate.js
+++ b/test/generate.js
@@ -27,7 +27,7 @@ function test (hmac_key) {
     t.equal(fstate.timestamp, msg.timestamp)
     t.equal(fstate.sequence, msg.sequence)
     t.deepEqual(fstate.queue, [])
-    t.deepEqual(state.queue, [msg])
+    t.deepEqual(state.queue.map(q => q.value), [msg])
 
     var msg_invalid = v.create(null, keys, hmac_key, {type: 'test'}, +new Date('2017-04-11 8:08 UTC'))
     t.ok(v.checkInvalidCheap(fstate, msg), 'cheap checks are invalid (on invalid message)')
@@ -51,15 +51,15 @@ function test (hmac_key) {
     t.equal(fstate.timestamp, msg.timestamp)
     t.equal(fstate.sequence, msg.sequence)
 
-    t.deepEqual(fstate.queue, [msg2])
-    t.deepEqual(state.queue, [msg])
+    t.deepEqual(fstate.queue.map(q => q.value), [msg2])
+    t.deepEqual(state.queue.map(q => q.value), [msg])
 
     var msg3 = v.create(fstate, keys, hmac_key, {type: 'test2'}, +new Date('2017-04-11 8:10 UTC'))
     t.equal(msg3.previous, v.id(msg2))
 
     state = v.append(state, hmac_key, msg3)
 
-    t.deepEqual(state.queue, [msg, msg2, msg3])
+    t.deepEqual(state.queue.map(q => q.value), [msg, msg2, msg3])
     console.log(state)
     t.end()
   })
@@ -75,7 +75,7 @@ function test (hmac_key) {
     t.equal(fstate.id, null)
     t.equal(fstate.timestamp, null)
     t.equal(fstate.sequence, null)
-    t.deepEqual(fstate.queue, [msg])
+    t.deepEqual(fstate.queue.map(q => q.value), [msg])
 
     t.equal(state.queued, 1)
 


### PR DESCRIPTION
This changes the queue format to be key value timestamp as used in secure-scuttlebutt. I have checked all the repos on github and this seems to only influence secure-scuttlebutt and bench-ssb. 