### PR TITLE
assert that  {signature}.sig.{curve} matches @{id}.{curve} on pubkey

### DIFF
--- a/index.js
+++ b/index.js
@@ -73,6 +73,12 @@ var isSupportedHash = exports.isSupportedHash = function (msg) {
   return msg.hash === 'sha256'
 }
 
+var isSigMatchesCurve = exports.isSigMatchesCurve = function (msg) {
+  var curve = /\.(\w+)/.exec(msg.author)
+  if(!(curve && curve[1])) return
+  return '.sig.'+curve[1] == msg.signature.substring(msg.signature.length - (curve[1].length+5))
+}
+
 var isInvalidShape = exports.isInvalidShape = function (msg) {
   if(
     !isObject(msg) ||
@@ -107,6 +113,8 @@ exports.checkInvalidCheap = function (state, msg) {
   //the message is just invalid
   if(!ref.isFeedId(msg.author))
     return new Error('invalid message: must have author')
+  if(!isSigMatchesCurve(msg))
+    return new Error('invalid message: signature type must match author type')
 
   //state is id, sequence, timestamp
   if(state) {
@@ -270,3 +278,8 @@ exports.appendNew = function (state, hmac_key, keys, content, timestamp) {
   state = exports.append(state, hmac_key, msg)
   return state
 }
+
+
+
+
+


### PR DESCRIPTION
I was talking to @dan-mi-sun about adding secp256k support to ssb, and I realized that I wasn't sure if the `.sig.{curve}` is enforced. Turns out it wasn't. This was an element of indeterminism because before this PR is merged you can put anything there, and it will be accepted, changing the hash of the message.

by merging this, compact encodings won't need to store the string after `.sig`