### PR TITLE
Add the encoded message length to the warning if it exceeds 8KB limit

### DIFF
--- a/index.js
+++ b/index.js
@@ -104,7 +104,7 @@ var isInvalidShape = exports.isInvalidShape = function (msg) {
   //we will fix at some point...
   var asJson = encode(msg)
   if (asJson.length > 8192) // 8kb
-    return new Error('encoded message must not be larger than 8192 bytes')
+    return new Error('Encoded message must not be larger than 8192 bytes. Current size is '+asJson.length)
 
   return isInvalidContent(msg.content)
 }


### PR DESCRIPTION
This would fix https://github.com/ssbc/patchwork/issues/1161 and should generally be of help. 