### PR TITLE
Add tests for invalid data

### DIFF
--- a/index.js
+++ b/index.js
@@ -103,7 +103,7 @@ var isInvalidShape = exports.isInvalidShape = function (msg) {
   //approach 32k. This is a weird legacy thing, obviously, that
   //we will fix at some point...
   var asJson = encode(msg)
-  if (asJson.length > 8192) // 8kb
+  if (Buffer.from(asJson, 'latin1').byteLength > 8192) // 8kb
     return new Error('Encoded message must not be larger than 8192 bytes. Current size is '+asJson.length)
 
   return isInvalidContent(msg.content)

--- a/test/data.js
+++ b/test/data.js
@@ -17,13 +17,23 @@ data.forEach(function (e,i) {
       var state = {feeds: {}, queue: []}
       state.feeds[e.msg.author] = e.state
       t.throws(function () {
-        try {
           state = v.append(state, e.cap, e.msg)
           console.log(e)
-        } catch(err) {
-          throw err
-        }
       })
       t.end()
     })
+})
+
+
+var invalid = require('./data/invalid_messages.json')
+invalid.forEach((message, messageIndex) => {
+  tape(`test invalid message (${messageIndex})`, (t) => {
+    t.plan(1)
+    console.log(message)
+    var state = {feeds: {}, queue: []}
+    t.throws(function () {
+      v.append(state, null, message)
+    })
+    t.end()
+  })
 })


### PR DESCRIPTION
Problem: We have 'invalid' data sitting in the repository, but we aren't
testing it. Also, the byte length check is validating the number of
characters instead of the number of bytes in the payload.

Solution: Add tests for the invalid data and fix up the code so that it
passes all (except one) test.

---

Help! One of the "invalid messages" decodes as:

```js
{
  previous: null,
  sequence: 1,
  author: '@AzvddyStfk/T95/3VuHxuJRwqqpBkCyoW7qHRCui2N4=.ed25519',
  timestamp: 1491901740000,
  hash: 'sha256',
  content: { type: 'Buffer', data: [ 104, 101, 108, 108, 111 ] },
  signature: 'gL5wIuUvM9JFZcqHteBFPwb/+XnX7zgWbDOr3W6A2ZMpgmWprb1/5Gj4FgtxzfyqLEVygPa/Ugvt7HtgLueNDA==.sig.ed25519'
}
```

Does anyone know why this should be invalid?